### PR TITLE
set ensure_ascii=False to handle non-English input srt

### DIFF
--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -234,9 +234,9 @@ The size of the list must remain the same as the one you received."""
             ContentDict: The model's response for context in next batch
         """
         if previous_message:
-            messages = [previous_message] + [{"role": "user", "parts": json.dumps(batch)}]
+            messages = [previous_message] + [{"role": "user", "parts": json.dumps(batch, ensure_ascii=False)}]
         else:
-            messages = [{"role": "user", "parts": json.dumps(batch)}]
+            messages = [{"role": "user", "parts": json.dumps(batch, ensure_ascii=False)}]
         response = model.generate_content(messages)
         translated_lines: list[SubtitleObject] = json.loads(response.text)
         


### PR DESCRIPTION
Set json dumps with ensure_ascii = false to handle non-English input subtitles. Gemini goes crazy without this setting when translating subtitles from non-English languages.