### PR TITLE
Add support for resuming translations and update to version 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,30 @@ gst.translate()
 
 This will translate the subtitles in the `subtitle.srt` file to French.
 
+### Resuming Partial Translation
+
+If you want to resume a partial translation (due to interruption or failure), you can simply re-run the script with the same parameters. GST will automatically detect the existence of a partially translated file and prompt which line to start from.
+You can also specify the `start_line` parameter directly in the script and skip the prompt:
+
+```python
+import gemini_srt_translator as gst
+gst.gemini_api_key = "your_gemini_api_key_here"
+gst.target_language = "French"
+gst.input_file = "subtitle.srt"
+gst.start_line = 20
+gst.translate()
+```
+
 ## Configuration
 
 You can further customize the translation settings by providing optional parameters:
 
-- `gemini_api_key2`: Second Gemini API key for additional quota.
-- `output_file`: Path to save the translated subtitle file.
+- `gemini_api_key2`: Second Gemini API key for additional quota. (for those using the free version of Pro models)
+- `output_file`: Path and name of the translated subtitle file.
+- `start_line`: Starting line number for translation.
 - `description`: Description of the translation job.
-- `model_name`: Model name to use for translation.
-- `batch_size`: Batch size for translation.
+- `model_name`: Model name to use for translation. (default: "gemini-2.0-flash")
+- `batch_size`: Batch size for translation. (default: 30)
 - `free_quota`: Use free quota for translation (default: True).
 
 Example:
@@ -74,7 +89,8 @@ gst.gemini_api_key2 = "your_gemini_api_key2_here"
 gst.target_language = "French"
 gst.input_file = "subtitle.srt"
 gst.output_file = "subtitle_translated.srt"
-gst.description = "Translation of subtitle file"
+gst.start_line = 20
+gst.description = "Translation of a medical television series, use medical terms"
 gst.model_name = "gemini-2.0-flash"
 gst.batch_size = 30
 gst.free_quota = True

--- a/gemini_srt_translator/__init__.py
+++ b/gemini_srt_translator/__init__.py
@@ -36,6 +36,7 @@ gemini_api_key2: str = None
 target_language: str = None
 input_file: str = None
 output_file: str = None
+start_line: int = None
 description: str = None
 model_name: str = None
 batch_size: int = None
@@ -60,8 +61,14 @@ def listmodels():
     Raises:
         Exception: If the Gemini API key is not provided.
     """
-    translator = GeminiSRTTranslator(gemini_api_key)
-    translator.listmodels()
+    translator = GeminiSRTTranslator(gemini_api_key = gemini_api_key)
+    models = translator.getmodels()
+    if models:
+        print("Available models:\n")
+        for model in models:
+            print(model)
+    else:
+        print("No models available or an error occurred while fetching models.")
 
 def translate():
     """
@@ -89,11 +96,14 @@ def translate():
     # (Optional) Path to save the translated subtitle file
     gst.output_file = "translated_subtitle.srt"
 
+    # (Optional) Line number to start translation from
+    gst.start_line = 120
+
     # (Optional) Additional description of the translation task
     gst.description = "This subtitle is from a TV Series called 'Friends'."
 
     # (Optional) Model name to use for translation
-    gst.model_name = "gemini-1.5-flash"
+    gst.model_name = "gemini-2.0-flash"
 
     # (Optional) Batch size for translation
     gst.batch_size = 30
@@ -114,6 +124,7 @@ def translate():
         'target_language': target_language,
         'input_file': input_file,
         'output_file': output_file,
+        'start_line': start_line,
         'description': description,
         'model_name': model_name,
         'batch_size': batch_size,

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -5,6 +5,7 @@ import json
 import json_repair
 import time
 import unicodedata as ud
+import signal
 
 import srt
 from srt import Subtitle
@@ -26,7 +27,7 @@ class GeminiSRTTranslator:
     A translator class that uses Gemini API to translate subtitles.
     """
     def __init__(self, gemini_api_key: str = None, gemini_api_key2: str = None, target_language: str = None, 
-                 input_file: str = None, output_file: str = None, description: str = None, 
+                 input_file: str = None, output_file: str = None, start_line: int = 1, description: str = None, 
                  model_name: str = "gemini-2.0-flash", batch_size: int = 30, free_quota: bool = True):
         """
         Initialize the translator with necessary parameters.
@@ -37,6 +38,7 @@ class GeminiSRTTranslator:
             target_language (str): Target language for translation
             input_file (str): Path to input subtitle file
             output_file (str): Path to output translated subtitle file
+            start_line (int): Line number to start translation from
             description (str): Additional instructions for translation
             model_name (str): Gemini model to use
             batch_size (int): Number of subtitles to process in each batch
@@ -50,21 +52,25 @@ class GeminiSRTTranslator:
         self.target_language = target_language
         self.input_file = input_file
         self.output_file = output_file
+        self.start_line = start_line
         self.description = description
         self.model_name = model_name
         self.batch_size = batch_size
         self.free_quota = free_quota
 
-    def listmodels(self):
-        """List available Gemini models that support content generation."""
+    def getmodels(self):
+        """Get available Gemini models that support content generation."""
         if not self.current_api_key:
-            raise Exception("Please provide a valid Gemini API key.")
+            print("Please provide a valid Gemini API key.")
+            exit(0)
 
         genai.configure(api_key=self.current_api_key)
         models = genai.list_models()
+        list_models = []
         for model in models:
             if "generateContent" in model.supported_generation_methods:
-                print(model.name.replace("models/", ""))
+                list_models.append(model.name.replace("models/", ""))
+        return list_models
 
     def translate(self):
         """
@@ -72,13 +78,16 @@ class GeminiSRTTranslator:
         and writes the translated subtitles to the output file.
         """
         if not self.current_api_key:
-            raise Exception("Please provide a valid Gemini API key.")
+            print("Please provide a valid Gemini API key.")
+            exit(0)
         
         if not self.target_language:
-            raise Exception("Please provide a target language.")
+            print("Please provide a target language.")
+            exit(0)
         
         if not self.input_file:
-            raise Exception("Please provide a subtitle file.")
+            print("Please provide a subtitle file.")
+            exit(0)
         
         if not self.output_file:
             self.output_file = ".".join(self.input_file.split(".")[:-1]) + "_translated.srt"
@@ -102,17 +111,53 @@ Dialogs must be translated as they are without any changes.
         if self.description:
             instruction += "\nAdditional user instruction: '" + self.description + "'"
 
+        models = self.getmodels()
         model = self._get_model(instruction)
 
-        with open(self.input_file, "r", encoding="utf-8") as original_file, open(self.output_file, "w", encoding="utf-8") as translated_file:
+        if self.model_name not in models:
+            print(f"Model {self.model_name} is not available. Please choose a different model.")
+            exit(0)
+
+        with open(self.input_file, "r", encoding="utf-8") as original_file:
             original_text = original_file.read()
             original_subtitle = list(srt.parse(original_text))
-            translated_subtitle = original_subtitle.copy()
+            try:
+                translated_file_exists = open(self.output_file, "r", encoding="utf-8")
+                translated_subtitle = list(srt.parse(translated_file_exists.read()))
+                print(f"Translated file {self.output_file} already exists. Loading existing translation...\n")
+                if self.start_line == 1:
+                    while True:
+                        try:
+                            self.start_line = int(input(f"Enter the line number to start from (1 to {len(original_subtitle)}): ").strip())
+                            if self.start_line < 1 or self.start_line > len(original_subtitle):
+                                print(f"Line number must be between 1 and {len(original_subtitle)}. Please try again.")
+                                continue
+                            break
+                        except ValueError:
+                            print("Invalid input. Please enter a valid number.")
 
-            i = 0
+            except FileNotFoundError:
+                translated_subtitle = original_subtitle.copy()
+            
+            if len(original_subtitle) != len(translated_subtitle):
+                print(f"Number of line of existing translated file does not match the number of lines in the original file.")
+                exit(0)
+
+            translated_file = open(self.output_file, "w", encoding="utf-8")
+
+            if self.start_line > len(original_subtitle) or self.start_line < 1:
+                print(f"Start line must be between 1 and {len(original_subtitle)}. Please check the input file.")
+                exit(0)
+            
+            i = self.start_line - 1
             total = len(original_subtitle)
             batch = []
             previous_message = None
+            if self.start_line > 1:
+                previous_message = {"role": "model", "parts": [{"text": json.dumps(
+                    [SubtitleObject(index=str(j), content=translated_subtitle[j].content) for j in range(max(0, i - self.batch_size), i)],
+                    ensure_ascii=False
+                )}]}
             reverted = 0
             delay = False
             delay_time = 30
@@ -120,18 +165,26 @@ Dialogs must be translated as they are without any changes.
             if 'pro' in self.model_name and self.free_quota:
                 delay = True
                 if not self.gemini_api_key2:
-                    print("Pro model and free user quota detected, enabling 30s delay between requests...")
+                    print("Pro model and free user quota detected, enabling 30s delay between requests...\n")
                 else:
                     delay_time = 15
-                    print("Pro model and free user quota detected, using secondary API key for additional quota...")
+                    print("Pro model and free user quota detected, using secondary API key for additional quota...\n")
 
             batch.append(SubtitleObject(index=str(i), content=original_subtitle[i].content))
             i += 1
 
-            print(f"Starting translation of {total} lines...")
+            print(f"Starting translation of {total - self.start_line + 1} lines...\n")
 
             if self.gemini_api_key2:
-                print(f"Starting with API {self.current_api_number}:")
+                print(f"Starting with API Key {self.current_api_number}\n")
+
+            def handle_interrupt(signal_received, frame):
+                print("\nTranslation interrupted. Saving partial results to file. Retry starting from line {}.".format(i - self.batch_size + 1))
+                if translated_file:
+                    translated_file.write(srt.compose(translated_subtitle))
+                exit(0)
+
+            signal.signal(signal.SIGINT, handle_interrupt)
 
             while len(batch) > 0:
                 if i < total and len(batch) < self.batch_size:
@@ -148,7 +201,7 @@ Dialogs must be translated as they are without any changes.
                     if reverted > 0:
                         self.batch_size += reverted
                         reverted = 0
-                        print("Increasing batch size back to {}...".format(self.batch_size))
+                        print("\nIncreasing batch size back to {}...\n".format(self.batch_size))
                     if i < total and len(batch) < self.batch_size:
                         batch.append(SubtitleObject(index=str(i), content=original_subtitle[i].content))
                         i += 1
@@ -157,14 +210,16 @@ Dialogs must be translated as they are without any changes.
                     
                     if "quota" in e_str:
                         if self._switch_api():
-                            print(f"\n🔄 API {self.backup_api_number} quota exceeded! Switching to API {self.current_api_number}...")
+                            print(f"\n🔄 API {self.backup_api_number} quota exceeded! Switching to API {self.current_api_number}...\n")
                             model = self._get_model(instruction)
                         else:
-                            print("\nAll API quotas exceeded, waiting 1 minute...")
+                            print("\nAll API quotas exceeded, waiting 1 minute...\n")
                             time.sleep(60)
                     else:
                         if self.batch_size == 1:
-                            raise Exception("Translation failed, aborting...")
+                            translated_file.write(srt.compose(translated_subtitle))
+                            print("\nTranslation failed. Saving partial results to file. Retry starting from line {}.".format(i + 1))
+                            exit(0)
                         if self.batch_size > 1:
                             decrement = min(10, self.batch_size - 1)
                             reverted += decrement
@@ -173,11 +228,12 @@ Dialogs must be translated as they are without any changes.
                                 batch.pop()
                             self.batch_size -= decrement
                         if "Gemini" in e_str:
-                            print(e_str)
+                            print("\n{}".format(e_str))
                         else:
-                            print("An unexpected error has occurred: {}".format(e_str))
-                        print("Decreasing batch size to {} and trying again...".format(self.batch_size))
-            
+                            print("\nAn unexpected error has occurred: {}".format(e_str))
+                        print("Decreasing batch size to {} and trying again...\n".format(self.batch_size))
+                
+            print("\nTranslation completed successfully!\n")
             translated_file.write(srt.compose(translated_subtitle))
 
     def _switch_api(self) -> bool:
@@ -236,9 +292,9 @@ Dialogs must be translated as they are without any changes.
             ContentDict: The model's response for context in next batch
         """
         if previous_message:
-            messages = [previous_message] + [{"role": "user", "parts": json.dumps(batch, ensure_ascii=False)}]
+            messages = [previous_message] + [{"role": "user", "parts": [{"text": json.dumps(batch, ensure_ascii=False)}]}]
         else:
-            messages = [{"role": "user", "parts": json.dumps(batch, ensure_ascii=False)}]
+            messages = [{"role": "user", "parts": [{"text": json.dumps(batch, ensure_ascii=False)}]}]
         response = model.generate_content(messages)
         translated_lines: list[SubtitleObject] = json_repair.loads(response.text)
         

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gemini-srt-translator",
-    version="1.3.4",
+    version="1.5.0",
     packages=find_packages(),
     install_requires=[
         "google-generativeai==0.8.4",


### PR DESCRIPTION
Introduce functionality to resume partial translations and handle interruptions. Add a `start_line` parameter for specifying the starting point of translations. Update the version to 1.5.0.