### PR TITLE
Add upgrade package functionality and skip upgrade option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Gemini SRT Translator is a tool designed to translate subtitle files using Googl
 To install Gemini SRT Translator, use pip:
 
 ```sh
-pip install gemini-srt-translator
+pip install --upgrade gemini-srt-translator
 ```
 
 ## Setup
@@ -60,10 +60,12 @@ You can also specify the `start_line` parameter directly in the script and skip 
 
 ```python
 import gemini_srt_translator as gst
+
 gst.gemini_api_key = "your_gemini_api_key_here"
 gst.target_language = "French"
 gst.input_file = "subtitle.srt"
 gst.start_line = 20
+
 gst.translate()
 ```
 
@@ -78,6 +80,7 @@ You can further customize the translation settings by providing optional paramet
 - `model_name`: Model name to use for translation. (default: "gemini-2.0-flash")
 - `batch_size`: Batch size for translation. (default: 30)
 - `free_quota`: Use free quota for translation (default: True).
+- `skip_upgrade`: Skip version upgrade check (default: False).
 
 Example:
 
@@ -94,6 +97,7 @@ gst.description = "Translation of a medical television series, use medical terms
 gst.model_name = "gemini-2.0-flash"
 gst.batch_size = 30
 gst.free_quota = True
+gst.skip_upgrade = True
 
 gst.translate()
 ```

--- a/gemini_srt_translator/__init__.py
+++ b/gemini_srt_translator/__init__.py
@@ -30,6 +30,7 @@
 """
 
 from .main import GeminiSRTTranslator
+from .utils import upgrade_package
 
 gemini_api_key: str = None
 gemini_api_key2: str = None
@@ -41,6 +42,7 @@ description: str = None
 model_name: str = None
 batch_size: int = None
 free_quota: bool = None
+skip_upgrade: bool = False
 
 def listmodels():
     """
@@ -111,6 +113,9 @@ def translate():
     # (Optional) Use free quota for translation (default: True)
     gst.free_quota = True
 
+    # (Optional) Skip package upgrade check
+    gst.skip_upgrade = True
+
     gst.translate()
     ```
     Raises:
@@ -130,6 +135,9 @@ def translate():
         'batch_size': batch_size,
         'free_quota': free_quota
     }
+
+    if not skip_upgrade:
+        upgrade_package("gemini-srt-translator")
     
     # Filter out None values
     filtered_params = {k: v for k, v in params.items() if v is not None}

--- a/gemini_srt_translator/utils.py
+++ b/gemini_srt_translator/utils.py
@@ -1,0 +1,80 @@
+import subprocess
+import sys
+import importlib.metadata
+import requests
+import time
+import threading
+
+def get_installed_version(package_name):
+    """Returns the installed version of a package, or None if not installed."""
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+def get_latest_pypi_version(package_name):
+    """Fetches the latest version of a package from PyPI."""
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        return data["info"]["version"]
+    return None
+
+def display_progress_bar(stop_event, package_name):
+    """Display a custom progress bar."""
+    width = 40
+    position = 0
+    direction = 1  # 1 for right, -1 for left
+    bar_length = 10  # Length of the moving part
+    
+    while not stop_event.is_set():
+        # Update position
+        position += direction
+        
+        # Change direction if hitting the boundaries
+        if position >= width - bar_length or position <= 0:
+            direction *= -1
+            
+        # Create the progress bar
+        bar = "[" + " " * position + "#" * bar_length + " " * (width - position - bar_length) + "]"
+        sys.stdout.write(f"\rInstalling {package_name}: {bar}")
+        sys.stdout.flush()
+        time.sleep(0.1)
+    
+    # Show complete when done
+    bar = "[" + "#" * width + "]"
+    sys.stdout.write(f"\rInstalling {package_name}: {bar} Complete!")
+    sys.stdout.flush()
+
+def upgrade_package(package_name):
+    """Upgrades the package using pip if an update is available."""
+    installed_version = get_installed_version(package_name)
+    latest_version = get_latest_pypi_version(package_name)
+
+    if installed_version < latest_version:
+        print(f"There is a new version of {package_name} available: {latest_version}.")
+        answer = input(f"Do you want to upgrade {package_name} from version {installed_version} to {latest_version}? (y/n): ")
+        if answer.lower() == 'y':
+            print(f"Upgrading {package_name}...")
+            
+            # Create and start a progress bar in a separate thread
+            stop_progress = threading.Event()
+            progress_thread = threading.Thread(target=display_progress_bar, args=(stop_progress, package_name))
+            progress_thread.start()
+            
+            try:
+                # Run pip install with stderr redirected to suppress pip update notifications
+                subprocess.run(
+                    [sys.executable, "-m", "pip", "install", "--upgrade", package_name, "--quiet", "--disable-pip-version-check"],
+                    check=True,
+                    stderr=subprocess.DEVNULL
+                )
+            finally:
+                # Stop the progress bar
+                stop_progress.set()
+                progress_thread.join()
+                
+            print(f"\n{package_name} upgraded to version {latest_version}.\n")
+        else:
+            print(f"{package_name} upgrade skipped.\n")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gemini-srt-translator",
-    version="1.5.0",
+    version="1.5.1",
     packages=find_packages(),
     install_requires=[
         "google-generativeai==0.8.4",


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `gemini_srt_translator` package, including the ability to skip version upgrade checks and a utility function for upgrading the package. 

Key changes include:

### Documentation Updates:
* Updated installation instructions in `README.md` to use `pip install --upgrade gemini-srt-translator`.
* Added `skip_upgrade` parameter to the list of customizable translation settings in `README.md`.
* Included `skip_upgrade` setting in the example usage in `README.md`.

### New Features:
* Introduced `skip_upgrade` parameter in the `gemini_srt_translator` module to allow users to skip the version upgrade check.
* Added a utility function `upgrade_package` to handle package upgrades, including a progress bar display during the upgrade process.

### Code Enhancements:
* Integrated the `upgrade_package` function into the `translate` function to perform version checks and upgrades unless `skip_upgrade` is set to `True`.

### Version Update:
* Updated the package version in `setup.py` from `1.5.0` to `1.5.1`