### PR TITLE
Save progress.log in the Same Directory as the Input SRT File

### DIFF
--- a/gemini_srt_translator/logger.py
+++ b/gemini_srt_translator/logger.py
@@ -297,31 +297,49 @@ def get_last_chunk_size() -> int:
     return _last_chunk_size
 
 
-def save_logs_to_file() -> None:
-    """Save the current progress to a file"""
-    with open("progress.log", "w", encoding="utf-8") as f:
-        if _last_progress:
-            # Write progress information in the same format as shown in terminal
-            current = _last_progress["current"] + _last_chunk_size
-            total = _last_progress["total"]
-            bar_length = _last_progress["bar_length"]
-            prefix = _last_progress["prefix"]
-            suffix = _last_progress["suffix"]
+def save_logs_to_file(log_file_path: str = "progress.log") -> bool:
+    """
+    Save the current progress to a file.
 
-            # Create the progress bar
-            progress_ratio = current / total if total > 0 else 0
-            filled_length = int(bar_length * progress_ratio)
-            bar = "█" * filled_length + "░" * (bar_length - filled_length)
-            percentage = int(100 * progress_ratio)
+    Args:
+        log_file_path (str): Path to the log file. Defaults to 'progress.log'.
 
-            # Format progress text just like in terminal
-            progress_text = f"{prefix} |{bar}| {percentage}% ({current}/{total})"
-            if suffix:
-                progress_text = f"{progress_text} {suffix}"
+    Returns:
+        bool: True if logs were saved successfully, False otherwise.
+    """
+    try:
+        # Ensure the directory exists
+        log_dir = os.path.dirname(log_file_path)
+        if log_dir and not os.path.exists(log_dir):
+            os.makedirs(log_dir)
 
-            f.write(f"{progress_text}\n\n")
+        with open(log_file_path, "w", encoding="utf-8") as f:
+            if _last_progress:
+                # Write progress information in the same format as shown in terminal
+                current = _last_progress["current"] + _last_chunk_size
+                total = _last_progress["total"]
+                bar_length = _last_progress["bar_length"]
+                prefix = _last_progress["prefix"]
+                suffix = _last_progress["suffix"]
 
-            # Write all the stored messages
-            if _previous_messages:
-                for msg in _previous_messages:
-                    f.write(f"{msg['message']}\n")
+                # Create the progress bar
+                progress_ratio = current / total if total > 0 else 0
+                filled_length = int(bar_length * progress_ratio)
+                bar = "█" * filled_length + "░" * (bar_length - filled_length)
+                percentage = int(100 * progress_ratio)
+
+                # Format progress text just like in terminal
+                progress_text = f"{prefix} |{bar}| {percentage}% ({current}/{total})"
+                if suffix:
+                    progress_text = f"{progress_text} {suffix}"
+
+                f.write(f"{progress_text}\n\n")
+
+                # Write all the stored messages
+                if _previous_messages:
+                    for msg in _previous_messages:
+                        f.write(f"{msg['message']}\n")
+        return True
+    except (PermissionError, OSError) as e:
+        warning(f"Failed to save logs to {log_file_path}: {e}")
+        return False

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -85,7 +85,6 @@ class GeminiSRTTranslator:
             error_log (bool): Whether to log errors to a file
             disable_streaming (bool): Whether to disable streaming for translation
         """
-
         if not output_file:
             try:
                 self.output_file = ".".join(self.input_file.split(".")[:-1]) + "_translated.srt"
@@ -101,6 +100,11 @@ class GeminiSRTTranslator:
         self.backup_api_number = 2
         self.target_language = target_language
         self.input_file = input_file
+        # Set log file path to the same directory as input file
+        if input_file and os.path.dirname(input_file):
+            self.log_file_path = os.path.join(os.path.dirname(input_file), "progress.log")
+        else:
+            self.log_file_path = "progress.log"
         self.start_line = start_line
         self.description = description
         self.model_name = model_name
@@ -321,7 +325,7 @@ class GeminiSRTTranslator:
                 if translated_file:
                     translated_file.write(srt.compose(translated_subtitle))
                 if self.error_log:
-                    save_logs_to_file()
+                    save_logs_to_file(self.log_file_path)
                 self._save_progress(max(1, i - len(batch) + max(0, last_chunk_size - 1) + 1))
                 exit(0)
 
@@ -434,11 +438,11 @@ class GeminiSRTTranslator:
                                 self.index_check = -1
                             info_with_progress(f"Resuming from line {i+1}...")
                         if self.error_log:
-                            save_logs_to_file()
+                            save_logs_to_file(self.log_file_path)
 
             success_with_progress("Translation completed successfully!")
             if self.error_log:
-                save_logs_to_file()
+                save_logs_to_file(self.log_file_path)
             translated_file.write(srt.compose(translated_subtitle))
 
             # Clear progress file on successful completion

--- a/tests/test_translate_alloptions_draganddrop.py
+++ b/tests/test_translate_alloptions_draganddrop.py
@@ -64,6 +64,10 @@ print()
 print(f"\033[91mTranslating the file. Model used: ”\033[92m{selected_model}\033[91m”. Please wait...\033[0m")
 print()
 gst.translate()
+if os.path.exists(gst.output_file):
+    with open(gst.output_file, 'a') as f:
+        f.flush()
+        os.fsync(f.fileno())
 
 # Text colored in yellow
 print()


### PR DESCRIPTION
Another one 😊
”progress.log” on Windows 11 (CMD) is not being saved. An error appears. So, a few changes are needed.

### Description:
This pull request addresses the issue where the log file (progress.log) was being written to the current working directory, which could cause PermissionError exceptions if the directory was not writable. The changes ensure that progress.log is saved in the same directory as the input SRT file, improving reliability and user experience.

### Problem
- The save_logs_to_file function in logger.py hardcoded the log file path to "progress.log", which attempted to write to the current working directory.
- This led to PermissionError issues when the working directory was not writable (e.g., system directories or locked folders).
- Users expect log files to be saved alongside the input SRT file for better organization.

### Solution
- Modified logger.py to make save_logs_to_file accept a log_file_path parameter, allowing dynamic log file paths.
- Updated main.py to compute the log file path based on the input SRT file’s directory and pass it to save_logs_to_file.
- Ensured the log file’s directory is created if it doesn’t exist, with error handling to prevent crashes.

### **Changes Made**

**1. logger.py:**
- Updated save_logs_to_file to accept a log_file_path parameter (defaults to "progress.log").
- Added logic to create the log file’s directory using os.makedirs if it doesn’t exist.
- Added error handling for PermissionError and OSError, logging warnings and returning False to prevent crashes.

**2. main.py:**
- In GeminiSRTTranslator.__init__, added self.log_file_path, set to "progress.log" in the input file’s directory (or "progress.log" if no directory is specified).
- Updated translate and the handle_interrupt function to pass self.log_file_path to save_logs_to_file.

**3. init.py:**

- No functional changes, but confirmed that the translate function correctly passes input_file to GeminiSRTTranslator, enabling the log file path computation.

### Notes

- The changes are backward-compatible; if input_file is not provided or has no directory, the log file defaults to "progress.log" in the working directory.
- No existing functionality is affected, and the changes only impact logging when error_log=True.

