### PR TITLE
[Feature] Add --include-timestamps to send subtitle times for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - 🎞️ **SRT Extraction**: Extract and translate SRT subtitles from video files automatically (requires [FFmpeg](https://ffmpeg.org/)).
 - 🎵 **Audio Context**: Extract audio from a video file or provide your own to improve translation accuracy (requires [FFmpeg](https://ffmpeg.org/)).
 - 📜 **Description Support**: Add a description to your translation job to guide the AI in using specific terminology or context.
+- ⏱️ **Timestamp Context**: Include subtitle timestamps to help AI match context from description for better speaker identification and grammatical gender accuracy.
 - 📋 **List Models**: Easily list all currently available Gemini models to choose the best fit for your needs.
 - 🔄 **Auto-Update**: Keep the tool updated with automatic version checking and update prompts.
 - 📝 **Logging**: Optional saving of progress and 'thinking' process logs for review.
@@ -160,6 +161,7 @@ gst translate \
   -o output_french.srt \
   --model gemini-2.5-flash \
   --batch-size 150 \
+  --include-timestamps \
   --temperature 0.7 \
   --description "Medical TV series, use medical terminology" \
   --progress-log \
@@ -287,6 +289,7 @@ gst.extract("audio")
 - `output_file`: Name of the translated file.
 - `start_line`: Starting line for translation.
 - `description`: Description of the translation job.
+- `include_timestamps`: Include subtitle timestamps in translation requests to match context from description. Useful for identifying speakers and applying correct grammatical gender. **Note: Uses more tokens.** Requires `gemini-2.5-flash` or newer (default: False).
 - `batch_size`: Batch size (default: 300).
 - `free_quota`: Signal GST that you are using a free quota (default: True).
 - `skip_upgrade`: Skip version upgrade check (default: False).
@@ -326,6 +329,7 @@ gst.audio_file = "audio.mp3"
 gst.extract_audio = False
 gst.start_line = 20
 gst.description = "Medical TV series, use medical terms"
+gst.include_timestamps = True
 gst.model_name = "gemini-2.5-pro-preview-03-25"
 gst.batch_size = 150
 gst.streaming = True

--- a/gemini_srt_translator/__init__.py
+++ b/gemini_srt_translator/__init__.py
@@ -48,6 +48,7 @@ extract_audio: bool = None
 isolate_voice: bool = None
 start_line: int = None
 description: str = None
+include_timestamps: bool = False
 model_name: str = None
 batch_size: int = None
 streaming: bool = None
@@ -238,6 +239,7 @@ def translate():
         "isolate_voice": isolate_voice,
         "start_line": start_line,
         "description": description,
+        "include_timestamps": include_timestamps,
         "model_name": model_name,
         "batch_size": batch_size,
         "streaming": streaming,

--- a/gemini_srt_translator/cli.py
+++ b/gemini_srt_translator/cli.py
@@ -132,6 +132,8 @@ def cmd_translate(args) -> None:
         gst.quiet = args.quiet
     if args.resume:
         gst.resume = args.resume
+    if args.include_timestamps:
+        gst.include_timestamps = args.include_timestamps
 
     # Execute translation
     try:
@@ -314,6 +316,10 @@ Examples:
     )
     translate_parser.add_argument(
         "--extract-audio", action="store_true", default=None, help="Extract audio from video for context"
+    )
+    translate_parser.add_argument(
+        "--include-timestamps", action="store_true", default=None,
+        help="Include timestamps in translation for context matching with description"
     )
 
     # Extract audio command

--- a/gemini_srt_translator/helpers.py
+++ b/gemini_srt_translator/helpers.py
@@ -13,6 +13,7 @@ def get_translate_instruction(
     thinking_compatible: bool,
     audio_file: Optional[str] = None,
     description: Optional[str] = None,
+    include_timestamps: bool = False,
 ) -> str:
     """
     Generates a structured instruction prompt for a subtitle translation task.
@@ -46,7 +47,7 @@ def get_translate_instruction(
   {{
     "index": "1",
     "text": "This is the first subtitle line.\\nThis is the second line.",
-{'    ' + audio_structure if audio_file else '...'}
+{'    ' + audio_structure if audio_file or include_timestamps else '...'}
   }}
 ]
 ```"""
@@ -108,6 +109,18 @@ Use this context to improve translation accuracy. These notes do not override co
 ## {section_number}. Reasoning Protocol
 {reasoning_instruction}"""
         prompt_parts.append(reasoning_protocol_section)
+
+    # --- Section 6: include timestamps ---
+    if include_timestamps and description and not audio_file:
+        section_number += 1
+        timestamp_context_section = f"""
+        ## {section_number}. Using Timestamps for Context Matching
+        Each subtitle includes `time_start` and `time_end` fields (in `MM:SS` format). Use these timestamps to match each subtitle with the transcription/context provided below.
+        - **Identify speakers**: Determine WHO is speaking and TO WHOM based on the context at that timestamp.
+        - **Apply correct gender**: Use appropriate grammatical gender for verbs and adjectives based on the speaker's gender (e.g., Polish: "zrobiłem" for male vs "zrobiłam" for female).
+        - **Scene context**: Understand the situation, location, and emotional tone of the scene to choose appropriate vocabulary and register.
+        """
+        prompt_parts.append(timestamp_context_section)
 
     return "\n---\n".join(prompt_parts).strip()
 


### PR DESCRIPTION
Add ability to include subtitle timestamps (time_start, time_end) in 
translation requests without requiring an audio file. This allows the 
model to match subtitles with transcription/context provided in 
--description for better translation accuracy.

- Identify speakers and apply correct grammatical gender
- Understand scene context for appropriate vocabulary
- Original timestamps preserved (no offset) when audio is not present