### PR TITLE
fix: handle json_repair producing nested lists during streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,16 @@
 # GST Files
 *.srt
 traduzir.py
+translate.py
 *.progress
 *.log
 *.mp3
 *.mp4
 *.mkv
+
+# Claude Code
+.claude/
+CLAUDE.md
 
 # Virtual environment
 venv/

--- a/gemini_srt_translator/logger.py
+++ b/gemini_srt_translator/logger.py
@@ -209,7 +209,8 @@ def progress_bar(
     if token_stats is not None:
         _token_stats = token_stats
 
-    _last_chunk_size = chunk_size
+    if chunk_size != 0:
+        _last_chunk_size = chunk_size
     if prompt_tokens is not None:
         _prompt_token_count += prompt_tokens
     if thoughts_tokens is not None:
@@ -223,14 +224,14 @@ def progress_bar(
     terminal_width = shutil.get_terminal_size().columns
 
     # Create the progress bar
-    progress_ratio = (current + chunk_size) / total if total > 0 else 0
+    progress_ratio = (current + _last_chunk_size) / total if total > 0 else 0
     filled_length = int(bar_length * progress_ratio)
     bar = "█" * filled_length + "░" * (bar_length - filled_length)
     percentage = int(100 * progress_ratio)
     if not isTranscribing:
-        progress_text = f"{prefix} |{bar}| {percentage}% ({current + chunk_size}/{total})"
+        progress_text = f"{prefix} |{bar}| {percentage}% ({current + _last_chunk_size}/{total})"
     else:
-        current_text = srt.timedelta_to_srt_timestamp(timedelta(seconds=current + chunk_size))
+        current_text = srt.timedelta_to_srt_timestamp(timedelta(seconds=current + _last_chunk_size))
         total_text = srt.timedelta_to_srt_timestamp(timedelta(seconds=total))
         progress_text = f"{prefix} |{bar}| {percentage}% ({current_text}/{total_text})"
     # Format the progress bar line

--- a/gemini_srt_translator/logger.py
+++ b/gemini_srt_translator/logger.py
@@ -171,6 +171,7 @@ def progress_bar(
     suffix: str = "",
     message: str = "",
     message_color: Color = None,
+    isDone: bool = True,
     isPrompt: bool = False,
     isLoading: bool = False,
     isSending: bool = False,
@@ -209,7 +210,7 @@ def progress_bar(
     if token_stats is not None:
         _token_stats = token_stats
 
-    if chunk_size != 0:
+    if chunk_size > _last_chunk_size or isDone:
         _last_chunk_size = chunk_size
     if prompt_tokens is not None:
         _prompt_token_count += prompt_tokens
@@ -460,6 +461,7 @@ def update_loading_animation(
         **_last_progress,
         message="",
         message_color=None,
+        isDone=False,
         isLoading=not isThinking,
         isThinking=isThinking,
         isTranscribing=isTranscribing,

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -165,7 +165,35 @@ class GeminiSRTTranslator:
         self.max_consecutive_errors = 5
         self.thought_signature = None
 
+        self.total_prompt_tokens = 0
+        self.total_candidates_tokens = 0
+        self.total_thoughts_tokens = 0
+        self.total_tokens = 0
+
         set_color_mode(use_colors)
+
+    def _accumulate_usage(self, usage_metadata):
+        """Accumulate token usage from a response's usage_metadata."""
+        if usage_metadata:
+            self.total_prompt_tokens += usage_metadata.prompt_token_count or 0
+            self.total_candidates_tokens += usage_metadata.candidates_token_count or 0
+            self.total_thoughts_tokens += getattr(usage_metadata, "thoughts_token_count", 0) or 0
+            self.total_tokens += usage_metadata.total_token_count or 0
+
+    def _log_token_usage(self, is_transcribing=False):
+        """Log accumulated token usage summary."""
+        if self.total_tokens > 0:
+            msg = f"Tokens used — prompt: {self.total_prompt_tokens:,}, completion: {self.total_candidates_tokens:,}, total: {self.total_tokens:,}"
+            if self.total_thoughts_tokens > 0:
+                msg += f" (thinking: {self.total_thoughts_tokens:,})"
+            info_with_progress(msg, isTranscribing=is_transcribing)
+
+    def _reset_token_usage(self):
+        """Reset token usage counters."""
+        self.total_prompt_tokens = 0
+        self.total_candidates_tokens = 0
+        self.total_thoughts_tokens = 0
+        self.total_tokens = 0
 
     def _get_translate_config(self):
         """Get the configuration for the translation model."""
@@ -442,6 +470,7 @@ class GeminiSRTTranslator:
         Main translation method. Reads the input subtitle file, translates it in batches,
         and writes the translated subtitles to the output file.
         """
+        self._reset_token_usage()
 
         if not self.ffmpeg_installed and self.video_file:
             error("FFmpeg is not installed. Please install FFmpeg to use video features.", ignore_quiet=True)
@@ -851,6 +880,7 @@ class GeminiSRTTranslator:
                 success_with_progress("\n\033[96m✅ \033[96mTranslation completed successfully!")
             else:
                 success_with_progress("\n✅ Translation completed successfully!")
+            self._log_token_usage()
             if self.progress_log:
                 save_logs_to_file(self.log_file_path)
             translated_file.write(srt.compose(translated_subtitle, reindex=False, strict=False))
@@ -988,6 +1018,7 @@ class GeminiSRTTranslator:
                     else:
                         info_with_progress(f"Batch {self.batch_number}.{retry} thinking process saved to file.")
                     save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
+                self._accumulate_usage(response.usage_metadata)
                 self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
                 if not isinstance(self.translated_batch, list) or not all(
                     isinstance(item, dict) for item in self.translated_batch
@@ -1039,6 +1070,8 @@ class GeminiSRTTranslator:
                         finished=False,
                     )
                     update_loading_animation(chunk_size=chunk_size)
+                if not blocked:
+                    self._accumulate_usage(chunk.usage_metadata)
 
             if len(self.translated_batch) == len(batch):
                 self._process_translated_lines(
@@ -1180,6 +1213,7 @@ class GeminiSRTTranslator:
         """
         Transcribe audio file into subtitles.
         """
+        self._reset_token_usage()
         extracted = False
         if self.video_file and not self.audio_file:
             self.audio_file = extract_audio_from_video(self.video_file, isolate_voice=self.isolate_voice)
@@ -1354,6 +1388,7 @@ class GeminiSRTTranslator:
                                             isTranscribing=True,
                                         )
                                     save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
+                                self._accumulate_usage(response.usage_metadata)
                             else:
                                 if blocked:
                                     break
@@ -1400,6 +1435,8 @@ class GeminiSRTTranslator:
                                                             ts_for_anim
                                                         ).total_seconds()
                                                         update_loading_animation(processed_seconds, isTranscribing=True)
+                                if not blocked:
+                                    self._accumulate_usage(chunk.usage_metadata)
 
                             if blocked:
                                 raise Exception("Content blocked by the API.")
@@ -1490,6 +1527,7 @@ class GeminiSRTTranslator:
                 )
             else:
                 success_with_progress(f"\nTranscription saved to {self.output_file}", isTranscribing=True)
+            self._log_token_usage(is_transcribing=True)
 
             if os.path.exists(self.progress_file):
                 os.remove(self.progress_file)

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -989,6 +989,10 @@ class GeminiSRTTranslator:
                         info_with_progress(f"Batch {self.batch_number}.{retry} thinking process saved to file.")
                     save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
                 self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
+                if not isinstance(self.translated_batch, list) or not all(
+                    isinstance(item, dict) for item in self.translated_batch
+                ):
+                    self.translated_batch = self._flatten_repaired_json(self.translated_batch)
             else:
                 if blocked:
                     break
@@ -1021,6 +1025,10 @@ class GeminiSRTTranslator:
                                     done_thinking = True
                                 response_text += part.text
                                 self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
+                    if not isinstance(self.translated_batch, list) or not all(
+                        isinstance(item, dict) for item in self.translated_batch
+                    ):
+                        self.translated_batch = self._flatten_repaired_json(self.translated_batch)
                     chunk_size = len(self.translated_batch)
                     if chunk_size == 0:
                         continue
@@ -1063,6 +1071,28 @@ class GeminiSRTTranslator:
         ]
         batch.clear()
         return previous_content
+
+    @staticmethod
+    def _flatten_repaired_json(data) -> list:
+        """
+        Flatten nested structures produced by json_repair when partial JSON
+        contains \\n-[ patterns (newline + bracket in subtitle text).
+
+        json_repair can misinterpret these as array boundaries, producing
+        nested lists like [[{...}, {...}], ["text"]] instead of [{...}, {...}].
+        This extracts all valid dict items from the nested structure.
+        """
+        result = []
+        if not isinstance(data, list):
+            return result
+        for item in data:
+            if isinstance(item, dict):
+                result.append(item)
+            elif isinstance(item, list):
+                for sub in item:
+                    if isinstance(sub, dict):
+                        result.append(sub)
+        return result
 
     def _process_translated_lines(
         self,

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -1021,7 +1021,7 @@ class GeminiSRTTranslator:
                     else:
                         info_with_progress(f"Batch {self.batch_number}.{retry} thinking process saved to file.")
                     save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
-                self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text, stream_stable=True)
+                self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
                 if not isinstance(self.translated_batch, list) or not all(
                     isinstance(item, dict) for item in self.translated_batch
                 ):
@@ -1585,7 +1585,7 @@ class GeminiSRTTranslator:
                             if blocked:
                                 raise Exception("Content blocked by the API.")
 
-                            transcription_json = json_repair.loads(response_text, stream_stable=True)
+                            transcription_json = json_repair.loads(response_text)
                             if not isinstance(transcription_json, list) or not all(
                                 isinstance(item, dict) for item in transcription_json
                             ):

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -169,29 +169,6 @@ class GeminiSRTTranslator:
 
         set_color_mode(use_colors)
 
-    def _accumulate_usage(self, usage_metadata):
-        """Accumulate token usage from a response's usage_metadata."""
-        if usage_metadata:
-            self.total_prompt_tokens += usage_metadata.prompt_token_count or 0
-            self.total_candidates_tokens += usage_metadata.candidates_token_count or 0
-            self.total_thoughts_tokens += getattr(usage_metadata, "thoughts_token_count", 0) or 0
-            self.total_tokens += usage_metadata.total_token_count or 0
-
-    def _log_token_usage(self, is_transcribing=False):
-        """Log accumulated token usage summary."""
-        if self.total_tokens > 0:
-            msg = f"Tokens used — prompt: {self.total_prompt_tokens:,}, completion: {self.total_candidates_tokens:,}, total: {self.total_tokens:,}"
-            if self.total_thoughts_tokens > 0:
-                msg += f" (thinking: {self.total_thoughts_tokens:,})"
-            info_with_progress(msg, isTranscribing=is_transcribing)
-
-    def _reset_token_usage(self):
-        """Reset token usage counters."""
-        self.total_prompt_tokens = 0
-        self.total_candidates_tokens = 0
-        self.total_thoughts_tokens = 0
-        self.total_tokens = 0
-
     def _get_translate_config(self):
         """Get the configuration for the translation model."""
         thinking_compatible = True
@@ -462,7 +439,6 @@ class GeminiSRTTranslator:
         Main translation method. Reads the input subtitle file, translates it in batches,
         and writes the translated subtitles to the output file.
         """
-        self._reset_token_usage()
 
         if not self.ffmpeg_installed and self.video_file:
             error(
@@ -904,7 +880,6 @@ class GeminiSRTTranslator:
                 success_with_progress("\n\033[96m✅ \033[96mTranslation completed successfully!")
             else:
                 success_with_progress("\n✅ Translation completed successfully!")
-            self._log_token_usage()
             if self.progress_log:
                 save_logs_to_file(self.log_file_path)
             translated_file.write(srt.compose(translated_subtitle, reindex=False, strict=False))
@@ -1046,8 +1021,7 @@ class GeminiSRTTranslator:
                     else:
                         info_with_progress(f"Batch {self.batch_number}.{retry} thinking process saved to file.")
                     save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
-                self._accumulate_usage(response.usage_metadata)
-                self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
+                self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text, stream_stable=True)
                 if not isinstance(self.translated_batch, list) or not all(
                     isinstance(item, dict) for item in self.translated_batch
                 ):
@@ -1095,11 +1069,13 @@ class GeminiSRTTranslator:
                                             )
                                         save_thoughts_to_file(thoughts_text, self.thoughts_file_path, retry)
                                 response_text += part.text
-                                self.translated_batch: list[SubtitleObject] = json_repair.loads(response_text)
-                    if not isinstance(self.translated_batch, list) or not all(
-                        isinstance(item, dict) for item in self.translated_batch
-                    ):
-                        self.translated_batch = self._flatten_repaired_json(self.translated_batch)
+                                self.translated_batch: list[SubtitleObject] = json_repair.loads(
+                                    response_text, stream_stable=True
+                                )
+                                if not isinstance(self.translated_batch, list) or not all(
+                                    isinstance(item, dict) for item in self.translated_batch
+                                ):
+                                    self.translated_batch = self._flatten_repaired_json(self.translated_batch)
                     chunk_size = len(self.translated_batch)
                     if chunk_size > 0:
                         self._process_translated_lines(
@@ -1185,28 +1161,6 @@ class GeminiSRTTranslator:
         ]
         batch.clear()
         return previous_content if self.preserve_context else []
-
-    @staticmethod
-    def _flatten_repaired_json(data) -> list:
-        """
-        Flatten nested structures produced by json_repair when partial JSON
-        contains \\n-[ patterns (newline + bracket in subtitle text).
-
-        json_repair can misinterpret these as array boundaries, producing
-        nested lists like [[{...}, {...}], ["text"]] instead of [{...}, {...}].
-        This extracts all valid dict items from the nested structure.
-        """
-        result = []
-        if not isinstance(data, list):
-            return result
-        for item in data:
-            if isinstance(item, dict):
-                result.append(item)
-            elif isinstance(item, list):
-                for sub in item:
-                    if isinstance(sub, dict):
-                        result.append(sub)
-        return result
 
     @staticmethod
     def _flatten_repaired_json(data) -> list:
@@ -1322,7 +1276,6 @@ class GeminiSRTTranslator:
         """
         Transcribe audio file into subtitles.
         """
-        self._reset_token_usage()
         extracted = False
         if self.video_file and not self.audio_file:
             self.audio_file = extract_audio_from_video(self.video_file, isolate_voice=self.isolate_voice)
@@ -1566,7 +1519,13 @@ class GeminiSRTTranslator:
                                                             retry,
                                                         )
                                                 response_text += part.text
-                                                transcription_json = json_repair.loads(response_text)
+                                                transcription_json = json_repair.loads(
+                                                    response_text, stream_stable=True
+                                                )
+                                                if not isinstance(transcription_json, list) or not all(
+                                                    isinstance(item, dict) for item in transcription_json
+                                                ):
+                                                    transcription_json = self._flatten_repaired_json(transcription_json)
                                                 if len(transcription_json) > 1:
                                                     if "time_end" in transcription_json[-2]:
                                                         ts_for_anim = _normalize_timestamp(
@@ -1626,7 +1585,11 @@ class GeminiSRTTranslator:
                             if blocked:
                                 raise Exception("Content blocked by the API.")
 
-                            transcription_json = json_repair.loads(response_text)
+                            transcription_json = json_repair.loads(response_text, stream_stable=True)
+                            if not isinstance(transcription_json, list) or not all(
+                                isinstance(item, dict) for item in transcription_json
+                            ):
+                                transcription_json = self._flatten_repaired_json(transcription_json)
 
                             for i in range(len(transcription_json)):
                                 start_ts = _normalize_timestamp(transcription_json[i]["time_start"])
@@ -1714,7 +1677,6 @@ class GeminiSRTTranslator:
                 )
             else:
                 success_with_progress(f"\nTranscription saved to {self.output_file}", isTranscribing=True)
-            self._log_token_usage(is_transcribing=True)
 
             if os.path.exists(self.progress_file):
                 os.remove(self.progress_file)


### PR DESCRIPTION
## Summary
- `json_repair.loads()` can misparse partial JSON during streaming when subtitle text contains `\n-[` patterns (newline + bracket, common in multi-speaker subtitles with sound effects like `-[Michelsson whimpers]\n-[Brahe grunts]`)
- It interprets `\n` as a real newline and `[` as a JSON array opener, producing nested lists like `[[{...}], ["text"]]` instead of a flat `[{...}]`
- This causes repeated "Gemini has returned a malformed object" errors and unnecessary batch retries
- Added `_flatten_repaired_json()` to recover valid dict items from nested structures, with validation in both streaming and non-streaming code paths

## Test plan
- [x] Tested with SRT file containing heavy bracket/sound-effect content that previously triggered the error
- [x] Full 609-line file translated with zero "malformed object" errors (previously failed repeatedly on lines 501-609)
- [x] Verified fix handles all json_repair edge cases: nested lists, mixed types, empty input