### PR TITLE
feat: add --token-report flag for machine-readable token usage with cost estimation

### DIFF
--- a/gemini_srt_translator/__init__.py
+++ b/gemini_srt_translator/__init__.py
@@ -61,6 +61,7 @@ thinking_budget: int = None
 thinking_level: Literal["minimal", "low", "medium", "high"] = None
 service_tier: Literal["standard", "flex", "priority"] = None
 token_stats: bool = None
+token_report: str = None
 preserve_context: bool = None
 temperature: float = None
 top_p: float = None
@@ -305,6 +306,7 @@ def translate():
         "thinking_level": thinking_level,
         "service_tier": service_tier,
         "token_stats": token_stats,
+        "token_report": token_report,
         "preserve_context": preserve_context,
         "temperature": temperature,
         "top_p": top_p,
@@ -435,6 +437,7 @@ def transcribe():
         "thinking_level": thinking_level,
         "service_tier": service_tier,
         "token_stats": token_stats,
+        "token_report": token_report,
         "temperature": temperature,
         "top_p": top_p,
         "top_k": top_k,

--- a/gemini_srt_translator/cli.py
+++ b/gemini_srt_translator/cli.py
@@ -55,6 +55,26 @@ def select_model_interactive(available_models: list) -> str:
             error("Please enter a valid number.")
 
 
+def resolve_token_report_path(args) -> Optional[str]:
+    """Resolve token report path based on inputs if not explicitly provided."""
+    if args.token_report is None:
+        return None
+    if args.token_report == "":
+        base_file = None
+        if getattr(args, "video_file", None):
+            base_file = args.video_file
+        elif getattr(args, "input_file", None):
+            base_file = args.input_file
+        elif getattr(args, "audio_file", None):
+            base_file = args.audio_file
+
+        if base_file:
+            root, _ = os.path.splitext(base_file)
+            return f"{root}_token_report.json"
+        return "token_report.json"
+    return args.token_report
+
+
 def cmd_translate(args) -> None:
     """Handle translate command."""
 
@@ -143,8 +163,8 @@ def cmd_translate(args) -> None:
         gst.request_type = args.request_type
     if args.token_stats:
         gst.token_stats = args.token_stats
-    if args.token_report:
-        gst.token_report = args.token_report
+    if args.token_report is not None:
+        gst.token_report = resolve_token_report_path(args)
     if args.no_context:
         gst.preserve_context = not args.no_context
 
@@ -293,8 +313,8 @@ def cmd_transcribe(args) -> None:
         gst.service_tier = args.service_tier
     if args.token_stats:
         gst.token_stats = args.token_stats
-    if args.token_report:
-        gst.token_report = args.token_report
+    if args.token_report is not None:
+        gst.token_report = resolve_token_report_path(args)
     if args.temperature:
         gst.temperature = args.temperature
     if args.top_p:
@@ -402,7 +422,13 @@ Examples:
         help="Service tier for API requests (paid plans only)",
     )
     translate_parser.add_argument("--token-stats", action="store_true", default=None, help="Show token usage")
-    translate_parser.add_argument("--token-report", default=None, help="Write per-run token usage JSON to this path")
+    translate_parser.add_argument(
+        "--token-report",
+        nargs="?",
+        const="",
+        default=None,
+        help="Write per-run token usage JSON to this path",
+    )
     translate_parser.add_argument("--no-context", action="store_true", default=None, help="No context between batches")
     translate_parser.add_argument("--no-streaming", action="store_true", default=None, help="Disable streaming")
     translate_parser.add_argument("--no-thinking", action="store_true", default=None, help="Disable thinking mode")
@@ -467,7 +493,13 @@ Examples:
         help="Service tier for API requests (paid plans only)",
     )
     transcribe_parser.add_argument("--token-stats", action="store_true", default=None, help="Show token usage")
-    transcribe_parser.add_argument("--token-report", default=None, help="Write per-run token usage JSON to this path")
+    transcribe_parser.add_argument(
+        "--token-report",
+        nargs="?",
+        const="",
+        default=None,
+        help="Write per-run token usage JSON to this path",
+    )
     transcribe_parser.add_argument("--skip-upgrade", action="store_true", default=None, help="Skip upgrade check")
     transcribe_parser.add_argument("--temperature", type=float, help="Temperature (0.0-2.0)")
     transcribe_parser.add_argument("--top-p", type=float, help="Top P (0.0-1.0)")

--- a/gemini_srt_translator/cli.py
+++ b/gemini_srt_translator/cli.py
@@ -143,6 +143,8 @@ def cmd_translate(args) -> None:
         gst.request_type = args.request_type
     if args.token_stats:
         gst.token_stats = args.token_stats
+    if args.token_report:
+        gst.token_report = args.token_report
     if args.no_context:
         gst.preserve_context = not args.no_context
 
@@ -291,6 +293,8 @@ def cmd_transcribe(args) -> None:
         gst.service_tier = args.service_tier
     if args.token_stats:
         gst.token_stats = args.token_stats
+    if args.token_report:
+        gst.token_report = args.token_report
     if args.temperature:
         gst.temperature = args.temperature
     if args.top_p:
@@ -301,6 +305,8 @@ def cmd_transcribe(args) -> None:
         gst.streaming = not args.no_streaming
     if args.no_thinking:
         gst.thinking = not args.no_thinking
+    if args.skip_upgrade:
+        gst.skip_upgrade = args.skip_upgrade
     if args.no_colors:
         gst.use_colors = not args.no_colors
     if args.progress_log:
@@ -396,6 +402,7 @@ Examples:
         help="Service tier for API requests (paid plans only)",
     )
     translate_parser.add_argument("--token-stats", action="store_true", default=None, help="Show token usage")
+    translate_parser.add_argument("--token-report", default=None, help="Write per-run token usage JSON to this path")
     translate_parser.add_argument("--no-context", action="store_true", default=None, help="No context between batches")
     translate_parser.add_argument("--no-streaming", action="store_true", default=None, help="Disable streaming")
     translate_parser.add_argument("--no-thinking", action="store_true", default=None, help="Disable thinking mode")
@@ -460,6 +467,8 @@ Examples:
         help="Service tier for API requests (paid plans only)",
     )
     transcribe_parser.add_argument("--token-stats", action="store_true", default=None, help="Show token usage")
+    transcribe_parser.add_argument("--token-report", default=None, help="Write per-run token usage JSON to this path")
+    transcribe_parser.add_argument("--skip-upgrade", action="store_true", default=None, help="Skip upgrade check")
     transcribe_parser.add_argument("--temperature", type=float, help="Temperature (0.0-2.0)")
     transcribe_parser.add_argument("--top-p", type=float, help="Top P (0.0-1.0)")
     transcribe_parser.add_argument("--top-k", type=int, help="Top K (>=0)")

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -6,7 +6,7 @@ import time
 import typing
 import unicodedata as ud
 from collections import Counter
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Literal
 
 import json_repair
@@ -96,6 +96,7 @@ class GeminiSRTTranslator:
         thinking_level: Literal["minimal", "low", "medium", "high"] = None,
         service_tier: Literal["standard", "flex", "priority"] = None,
         token_stats: bool = False,
+        token_report: str = None,
         preserve_context: bool = True,
         temperature: float = None,
         top_p: float = None,
@@ -156,6 +157,7 @@ class GeminiSRTTranslator:
         self.thinking_level = thinking_level
         self.service_tier = service_tier
         self.token_stats = token_stats
+        self.token_report = token_report
         self.preserve_context = preserve_context
         self.temperature = temperature
         self.top_p = top_p
@@ -173,6 +175,11 @@ class GeminiSRTTranslator:
         self.audio_part = None
         self.token_limit = 0
         self.token_count = 0
+        self._report_prompt_tokens = 0
+        self._report_thoughts_tokens = 0
+        self._report_output_tokens = 0
+        self._report_total_tokens = 0
+        self._start_time = time.time()
         self.translated_batch = []
         self.srt_extracted = False
         self.audio_extracted = False
@@ -723,6 +730,7 @@ class GeminiSRTTranslator:
                 if self.progress_log:
                     save_logs_to_file(self.log_file_path)
                 self._save_progress(max(1, i - len(batch) + max(0, last_chunk_size - 1) + 1))
+                self._write_token_report("translate")
                 exit(0)
 
             signal.signal(signal.SIGINT, handle_interrupt)
@@ -901,6 +909,8 @@ class GeminiSRTTranslator:
             translated_file.write(srt.compose(translated_subtitle, reindex=False, strict=False))
             translated_file.close()
 
+            self._write_token_report("translate")
+
             if self.audio_file and os.path.exists(self.audio_file) and self.audio_extracted:
                 os.remove(self.audio_file)
 
@@ -1003,6 +1013,82 @@ class GeminiSRTTranslator:
             return False
         return True
 
+    def _accumulate_report_tokens(
+        self,
+        prompt_tokens: int | None = None,
+        thoughts_tokens: int | None = None,
+        output_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        if prompt_tokens is not None:
+            self._report_prompt_tokens += prompt_tokens
+        if thoughts_tokens is not None:
+            self._report_thoughts_tokens += thoughts_tokens
+        if output_tokens is not None:
+            self._report_output_tokens += output_tokens
+        if total_tokens is not None:
+            self._report_total_tokens += total_tokens
+
+    def _calculate_cost(self) -> dict | None:
+        pricing_path = os.path.join(os.path.dirname(__file__), "pricing.json")
+        try:
+            with open(pricing_path, "r", encoding="utf-8") as f:
+                pricing = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+        tier = self.service_tier or "standard"
+        model_pricing = pricing.get("models", {}).get(self.model_name)
+        if not model_pricing:
+            return None
+
+        rates = model_pricing.get(tier) or model_pricing.get("standard")
+        if not rates:
+            return None
+
+        input_cost = self._report_prompt_tokens / 1_000_000 * rates["input"]
+        output_cost = (self._report_thoughts_tokens + self._report_output_tokens) / 1_000_000 * rates["output"]
+        return {
+            "input": round(input_cost, 6),
+            "output": round(output_cost, 6),
+            "total": round(input_cost + output_cost, 6),
+            "tier": tier,
+        }
+
+    def _write_token_report(self, mode: str) -> None:
+        if not self.token_report:
+            return
+        report = {
+            "timestamp": datetime.now().isoformat(),
+            "mode": mode,
+            "model": self.model_name,
+            "output_file": self.output_file,
+            "duration_seconds": round(time.time() - self._start_time, 2),
+            "tokens": {
+                "prompt": self._report_prompt_tokens,
+                "thoughts": self._report_thoughts_tokens,
+                "output": self._report_output_tokens,
+                "total": self._report_total_tokens,
+            },
+        }
+        if self.input_file:
+            report["input_file"] = self.input_file
+        if self.audio_file:
+            report["audio_file"] = self.audio_file
+        if mode == "translate" and self.target_language:
+            report["target_language"] = self.target_language
+        cost = self._calculate_cost()
+        if cost:
+            report["cost"] = cost
+        try:
+            report_dir = os.path.dirname(self.token_report)
+            if report_dir and not os.path.exists(report_dir):
+                os.makedirs(report_dir)
+            with open(self.token_report, "w", encoding="utf-8") as f:
+                json.dump(report, f, indent=2)
+        except (PermissionError, OSError) as e:
+            warning(f"Failed to write token report to {self.token_report}: {e}")
+
     def _process_batch(
         self,
         batch: list[SubtitleObject],
@@ -1087,6 +1173,12 @@ class GeminiSRTTranslator:
                     output_tokens=response.usage_metadata.candidates_token_count,
                     total_tokens=response.usage_metadata.total_token_count,
                 )
+                self._accumulate_report_tokens(
+                    prompt_tokens=response.usage_metadata.prompt_token_count,
+                    thoughts_tokens=response.usage_metadata.thoughts_token_count,
+                    output_tokens=response.usage_metadata.candidates_token_count,
+                    total_tokens=response.usage_metadata.total_token_count,
+                )
             else:
                 if blocked:
                     break
@@ -1140,6 +1232,28 @@ class GeminiSRTTranslator:
                         chunk_size=chunk_size,
                         isThinking=self.thinking and not done_thinking,
                         token_stats=self.token_stats,
+                        prompt_tokens=(
+                            chunk.usage_metadata.prompt_token_count - previous_prompt_tokens
+                            if chunk.usage_metadata and chunk.usage_metadata.prompt_token_count
+                            else None
+                        ),
+                        thoughts_tokens=(
+                            chunk.usage_metadata.thoughts_token_count - previous_thoughts_tokens
+                            if chunk.usage_metadata and chunk.usage_metadata.thoughts_token_count
+                            else None
+                        ),
+                        output_tokens=(
+                            chunk.usage_metadata.candidates_token_count - previous_output_tokens
+                            if chunk.usage_metadata and chunk.usage_metadata.candidates_token_count
+                            else None
+                        ),
+                        total_tokens=(
+                            chunk.usage_metadata.total_token_count - previous_total_tokens
+                            if chunk.usage_metadata and chunk.usage_metadata.total_token_count
+                            else None
+                        ),
+                    )
+                    self._accumulate_report_tokens(
                         prompt_tokens=(
                             chunk.usage_metadata.prompt_token_count - previous_prompt_tokens
                             if chunk.usage_metadata and chunk.usage_metadata.prompt_token_count
@@ -1416,6 +1530,7 @@ class GeminiSRTTranslator:
                     f.write(transcribed_subtitle)
             if self.progress_log:
                 save_logs_to_file(self.log_file_path)
+            self._write_token_report("transcribe")
             exit(0)
 
         signal.signal(signal.SIGINT, handle_interrupt)
@@ -1530,6 +1645,12 @@ class GeminiSRTTranslator:
                                     output_tokens=response.usage_metadata.candidates_token_count,
                                     total_tokens=response.usage_metadata.total_token_count,
                                 )
+                                self._accumulate_report_tokens(
+                                    prompt_tokens=response.usage_metadata.prompt_token_count,
+                                    thoughts_tokens=response.usage_metadata.thoughts_token_count,
+                                    output_tokens=response.usage_metadata.candidates_token_count,
+                                    total_tokens=response.usage_metadata.total_token_count,
+                                )
                             else:
                                 if blocked:
                                     break
@@ -1589,6 +1710,28 @@ class GeminiSRTTranslator:
                                             isTranscribing=True,
                                             isThinking=self.thinking and not done_thinking,
                                             token_stats=self.token_stats,
+                                            prompt_tokens=(
+                                                chunk.usage_metadata.prompt_token_count - previous_prompt_tokens
+                                                if chunk.usage_metadata and chunk.usage_metadata.prompt_token_count
+                                                else None
+                                            ),
+                                            thoughts_tokens=(
+                                                chunk.usage_metadata.thoughts_token_count - previous_thoughts_tokens
+                                                if chunk.usage_metadata and chunk.usage_metadata.thoughts_token_count
+                                                else None
+                                            ),
+                                            output_tokens=(
+                                                chunk.usage_metadata.candidates_token_count - previous_output_tokens
+                                                if chunk.usage_metadata and chunk.usage_metadata.candidates_token_count
+                                                else None
+                                            ),
+                                            total_tokens=(
+                                                chunk.usage_metadata.total_token_count - previous_total_tokens
+                                                if chunk.usage_metadata and chunk.usage_metadata.total_token_count
+                                                else None
+                                            ),
+                                        )
+                                        self._accumulate_report_tokens(
                                             prompt_tokens=(
                                                 chunk.usage_metadata.prompt_token_count - previous_prompt_tokens
                                                 if chunk.usage_metadata and chunk.usage_metadata.prompt_token_count
@@ -1731,10 +1874,12 @@ class GeminiSRTTranslator:
                 os.remove(self.progress_file)
             if self.progress_log:
                 save_logs_to_file(self.log_file_path)
+            self._write_token_report("transcribe")
             if extracted and self.audio_file and os.path.exists(self.audio_file):
                 os.remove(self.audio_file)
 
         except Exception as e:
             error(f"Error during transcription: {e}", ignore_quiet=True)
             self._save_transcribe_progress(last_saved_time)
+            self._write_token_report("transcribe")
             exit(1)

--- a/gemini_srt_translator/pricing.json
+++ b/gemini_srt_translator/pricing.json
@@ -1,0 +1,64 @@
+{
+  "currency": "USD",
+  "updated": "2026-06-23",
+  "source": "https://ai.google.dev/gemini-api/docs/pricing",
+  "unit": "per 1 million tokens",
+  "models": {
+    "gemini-3.5-flash": {
+      "standard": { "input": 1.50, "output": 9.00 },
+      "batch": { "input": 0.75, "output": 4.50 },
+      "flex": { "input": 0.75, "output": 4.50 },
+      "priority": { "input": 2.70, "output": 16.20 }
+    },
+    "gemini-3.1-flash-lite": {
+      "standard": { "input": 0.25, "output": 1.50 },
+      "batch": { "input": 0.125, "output": 0.75 },
+      "flex": { "input": 0.125, "output": 0.75 },
+      "priority": { "input": 0.45, "output": 2.70 }
+    },
+    "gemini-3.1-pro-preview": {
+      "standard": { "input": 2.00, "output": 12.00 },
+      "batch": { "input": 1.00, "output": 6.00 },
+      "flex": { "input": 1.00, "output": 6.00 },
+      "priority": { "input": 3.60, "output": 21.60 }
+    },
+    "gemini-3-flash-preview": {
+      "standard": { "input": 0.50, "output": 3.00 },
+      "batch": { "input": 0.25, "output": 1.50 },
+      "flex": { "input": 0.25, "output": 1.50 },
+      "priority": { "input": 0.90, "output": 5.40 }
+    },
+    "gemini-2.5-pro": {
+      "standard": { "input": 1.25, "output": 10.00 },
+      "batch": { "input": 0.625, "output": 5.00 },
+      "flex": { "input": 0.625, "output": 5.00 },
+      "priority": { "input": 2.25, "output": 18.00 }
+    },
+    "gemini-2.5-flash": {
+      "standard": { "input": 0.30, "output": 2.50 },
+      "batch": { "input": 0.15, "output": 1.25 },
+      "flex": { "input": 0.15, "output": 1.25 },
+      "priority": { "input": 0.54, "output": 4.50 }
+    },
+    "gemini-2.5-flash-lite": {
+      "standard": { "input": 0.10, "output": 0.40 },
+      "batch": { "input": 0.05, "output": 0.20 },
+      "flex": { "input": 0.05, "output": 0.20 },
+      "priority": { "input": 0.18, "output": 0.72 }
+    },
+    "gemini-2.5-flash-lite-preview": {
+      "standard": { "input": 0.10, "output": 0.40 },
+      "batch": { "input": 0.05, "output": 0.20 },
+      "flex": { "input": 0.05, "output": 0.20 },
+      "priority": { "input": 0.18, "output": 0.72 }
+    },
+    "gemini-2.0-flash": {
+      "standard": { "input": 0.10, "output": 0.40 },
+      "batch": { "input": 0.05, "output": 0.20 }
+    },
+    "gemini-2.0-flash-lite": {
+      "standard": { "input": 0.075, "output": 0.30 },
+      "batch": { "input": 0.0375, "output": 0.15 }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ requires-python = ">=3.10"
 [project.scripts]
 gemini-srt-translator = "gemini_srt_translator.cli:main"
 gst = "gemini_srt_translator.cli:main"
+
+[tool.setuptools.package-data]
+gemini_srt_translator = ["*.json"]


### PR DESCRIPTION
## Problem

The existing `--token-stats` flag only displays token counts in the terminal progress bar, which is unusable in server/API contexts (e.g. calling `gst` via `shell_exec()` from a web service). There is no way to capture token usage programmatically.

## Solution

Adds a new `--token-report=<path>` CLI flag (available on both `translate` and `transcribe`) that writes a JSON file after the run completes.

### Example output

```json
{
  "timestamp": "2026-06-23T01:56:58Z",
  "mode": "translate",
  "model": "gemini-3.5-flash",
  "output_file": "subtitle_de.srt",
  "input_file": "subtitle.srt",
  "target_language": "German",
  "duration_seconds": 23.45,
  "tokens": {
    "prompt": 1388,
    "thoughts": 4259,
    "output": 1152,
    "total": 6799
  },
  "cost": {
    "input": 0.002082,
    "output": 0.048699,
    "total": 0.050781,
    "tier": "standard"
  }
}
```

### Features

- **Per-run token breakdown**: prompt, thoughts, output, total
- **Cost estimation**: bundles `pricing.json` with per-tier rates (Standard/Batch/Flex/Priority) for all Gemini text models. Thoughts are billed at the output rate per Google's pricing docs.
- **Conditional fields**: `input_file`, `audio_file`, and `target_language` only appear when relevant
- **Written on**: successful completion, SIGINT interrupt (partial data), and transcription error
- **Zero overhead** when flag is not passed
- **`--skip-upgrade`** also added to `transcribe` subcommand (was only on `translate`)

### Usage

```bash
gst translate --skip-upgrade --token-report=/tmp/report.json -i subtitle.srt -l German
gst transcribe --skip-upgrade --token-report=/tmp/report.json -a audio.mp3 -o output.srt
```

### Files changed

- `gemini_srt_translator/__init__.py` — `token_report` module var + pass-through
- `gemini_srt_translator/cli.py` — `--token-report` arg on both subparsers + `--skip-upgrade` on transcribe
- `gemini_srt_translator/main.py` — token accumulation, `_calculate_cost()`, `_write_token_report()`
- `gemini_srt_translator/pricing.json` — pricing data for all Gemini text models
- `pyproject.toml` — `package-data` declaration so `pricing.json` ships with pip install