### PR TITLE
Avoid exiting when ffmpeg is missing during checks

### DIFF
--- a/gemini_srt_translator/ffmpeg_utils.py
+++ b/gemini_srt_translator/ffmpeg_utils.py
@@ -206,7 +206,13 @@ def extract_srt_from_video(video_path):
 def check_ffmpeg_installation():
     """Checks if FFmpeg is installed and accessible."""
     try:
-        _run_command(["ffmpeg", "-version"], capture_output=True)
+        subprocess.run(
+            ["ffmpeg", "-version"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False

--- a/tests/test_ffmpeg_utils.py
+++ b/tests/test_ffmpeg_utils.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+
+from gemini_srt_translator.ffmpeg_utils import check_ffmpeg_installation
+
+
+class FfmpegUtilsTests(unittest.TestCase):
+    def test_check_ffmpeg_installation_returns_false_when_binary_is_missing(self):
+        with patch(
+            "gemini_srt_translator.ffmpeg_utils.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            self.assertFalse(check_ffmpeg_installation())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid using the shared command runner for the FFmpeg availability probe
- return `False` when the `ffmpeg` binary is missing instead of exiting the process
- add a unittest covering the missing-binary path

## Why
`GeminiSRTTranslator` checks FFmpeg availability during initialization. Because `_run_command()` calls `sys.exit(1)` on `FileNotFoundError`, SRT-only translation currently exits when FFmpeg is not installed, even if no video or audio feature is being used.

Video and audio extraction still require FFmpeg because the operational command runner is unchanged.

## Validation
- `python -m unittest tests/test_ffmpeg_utils.py`
- `python -m py_compile gemini_srt_translator/ffmpeg_utils.py tests/test_ffmpeg_utils.py`