### PR TITLE
Exit nonzero when translation is interrupted

### DIFF
--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -731,7 +731,7 @@ class GeminiSRTTranslator:
                     save_logs_to_file(self.log_file_path)
                 self._save_progress(max(1, i - len(batch) + max(0, last_chunk_size - 1) + 1))
                 self._write_token_report("translate")
-                exit(0)
+                exit(130)
 
             signal.signal(signal.SIGINT, handle_interrupt)
 

--- a/tests/test_interrupted_translation.py
+++ b/tests/test_interrupted_translation.py
@@ -1,0 +1,47 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gemini_srt_translator.main import GeminiSRTTranslator
+
+
+class InterruptedTranslationTests(unittest.TestCase):
+    def test_translation_interruption_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_file = root / "sample.en.srt"
+            output_file = root / "sample.zh.srt"
+            input_file.write_text("1\n00:00:01,000 --> 00:00:02,000\nHello\n", encoding="utf-8")
+
+            translator = GeminiSRTTranslator(
+                gemini_api_key="test-key",
+                target_language="Simplified Chinese",
+                input_file=str(input_file),
+                output_file=str(output_file),
+                model_name="gemini-flash-latest",
+                batch_size=1,
+                use_colors=False,
+                resume=False,
+            )
+
+            with (
+                patch.object(translator, "getmodels", return_value=["gemini-flash-latest"]),
+                patch.object(translator, "_get_token_limit", return_value=None),
+                patch.object(translator, "_validate_token_size", return_value=True),
+                patch.object(translator, "_process_batch", side_effect=RuntimeError("api failed")),
+                patch("gemini_srt_translator.main.time.sleep", return_value=None),
+                patch("gemini_srt_translator.main.progress_bar", return_value=None),
+                patch("gemini_srt_translator.main.info_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.warning_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.error_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.success_with_progress", return_value=None),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    translator.translate()
+
+            self.assertNotEqual(raised.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- return a non-zero exit code when translation is interrupted
- add a regression test for the consecutive-error interruption path

## Why
The translation SIGINT handler saves partial output and a progress file, but currently exits with status 0. Callers that invoke `gst translate` through subprocess cannot distinguish a completed translation from an interrupted run, and may treat the partial output as successful.

Using exit code 130 follows the conventional SIGINT status and lets automation detect the interrupted translation.

## Validation
- `python -m unittest tests/test_interrupted_translation.py`
- `python -m py_compile gemini_srt_translator/main.py tests/test_interrupted_translation.py`