### PR TITLE
Preserve resume output until translation save

### DIFF
--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import signal
+import stat
 import tempfile
 import time
 import typing
@@ -371,6 +372,12 @@ class GeminiSRTTranslator:
         filename = os.path.basename(path)
         temp_path = None
         file_descriptor = None
+        try:
+            output_mode = stat.S_IMODE(os.stat(path).st_mode)
+        except FileNotFoundError:
+            current_umask = os.umask(0)
+            os.umask(current_umask)
+            output_mode = 0o666 & ~current_umask
 
         try:
             file_descriptor, temp_path = tempfile.mkstemp(
@@ -384,6 +391,7 @@ class GeminiSRTTranslator:
                 temp_file.write(text)
                 temp_file.flush()
                 os.fsync(temp_file.fileno())
+            os.chmod(temp_path, output_mode)
             os.replace(temp_path, path)
             temp_path = None
         finally:

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import signal
+import tempfile
 import time
 import typing
 import unicodedata as ud
@@ -364,6 +365,36 @@ class GeminiSRTTranslator:
         except Exception as e:
             warning_with_progress(f"Failed to save progress: {e}")
 
+    def _write_text_atomically(self, path: str, text: str):
+        """Write text to a sibling temporary file before replacing the target."""
+        directory = os.path.dirname(os.path.abspath(path)) or "."
+        filename = os.path.basename(path)
+        temp_path = None
+        file_descriptor = None
+
+        try:
+            file_descriptor, temp_path = tempfile.mkstemp(
+                prefix=f".{filename}.",
+                suffix=".tmp",
+                dir=directory,
+                text=True,
+            )
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as temp_file:
+                file_descriptor = None
+                temp_file.write(text)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, path)
+            temp_path = None
+        finally:
+            if file_descriptor is not None:
+                os.close(file_descriptor)
+            if temp_path and os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def _write_translated_subtitles(self, translated_subtitle):
+        self._write_text_atomically(self.output_file, srt.compose(translated_subtitle, reindex=False, strict=False))
+
     def _save_transcribe_progress(self, time_in_seconds):
         """Save current transcription progress to a temporary file."""
         if not self.progress_file:
@@ -568,8 +599,8 @@ class GeminiSRTTranslator:
             original_text = original_file.read()
             original_subtitle = list(srt.parse(original_text))
             try:
-                translated_file_exists = open(self.output_file, "r", encoding="utf-8")
-                translated_subtitle = list(srt.parse(translated_file_exists.read()))
+                with open(self.output_file, "r", encoding="utf-8") as translated_file_exists:
+                    translated_subtitle = list(srt.parse(translated_file_exists.read()))
                 if self.use_colors:
                     info(
                         f"Translated file \033[90m{self.output_file}\033[94m already exists. Loading existing translation...\n"
@@ -605,8 +636,6 @@ class GeminiSRTTranslator:
                     ignore_quiet=True,
                 )
                 exit(1)
-
-            translated_file = open(self.output_file, "w", encoding="utf-8")
 
             if self.start_line > len(original_subtitle) or self.start_line < 1:
                 error(
@@ -725,9 +754,7 @@ class GeminiSRTTranslator:
                     f"Translation interrupted. Saving partial results to file. Progress saved.",
                     chunk_size=max(0, last_chunk_size - 1),
                 )
-                if translated_file:
-                    translated_file.write(srt.compose(translated_subtitle, reindex=False, strict=False))
-                    translated_file.close()
+                self._write_translated_subtitles(translated_subtitle)
                 if self.progress_log:
                     save_logs_to_file(self.log_file_path)
                 self._save_progress(max(1, i - len(batch) + max(0, last_chunk_size - 1) + 1))
@@ -907,8 +934,7 @@ class GeminiSRTTranslator:
                 success_with_progress("✅ Translation completed successfully!")
             if self.progress_log:
                 save_logs_to_file(self.log_file_path)
-            translated_file.write(srt.compose(translated_subtitle, reindex=False, strict=False))
-            translated_file.close()
+            self._write_translated_subtitles(translated_subtitle)
 
             self._write_token_report("translate")
 

--- a/tests/test_interrupted_translation.py
+++ b/tests/test_interrupted_translation.py
@@ -1,4 +1,6 @@
 import json
+import os
+import stat
 import tempfile
 import unittest
 from pathlib import Path
@@ -58,6 +60,32 @@ class InterruptedTranslationTests(unittest.TestCase):
                     translator.translate()
 
             self.assertEqual(raised.exception.code, "output remained intact")
+
+    @unittest.skipIf(os.name == "nt", "POSIX permission bits are not meaningful on Windows")
+    def test_atomic_write_uses_normal_file_permissions_for_new_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "sample.zh.srt"
+            translator = GeminiSRTTranslator(output_file=str(output_file))
+            old_umask = os.umask(0o022)
+            try:
+                translator._write_text_atomically(str(output_file), "translated")
+            finally:
+                os.umask(old_umask)
+
+            self.assertEqual(stat.S_IMODE(output_file.stat().st_mode), 0o644)
+
+    @unittest.skipIf(os.name == "nt", "POSIX permission bits are not meaningful on Windows")
+    def test_atomic_write_preserves_existing_output_permissions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "sample.zh.srt"
+            output_file.write_text("previous", encoding="utf-8")
+            output_file.chmod(0o664)
+            translator = GeminiSRTTranslator(output_file=str(output_file))
+
+            translator._write_text_atomically(str(output_file), "translated")
+
+            self.assertEqual(output_file.read_text(encoding="utf-8"), "translated")
+            self.assertEqual(stat.S_IMODE(output_file.stat().st_mode), 0o664)
 
     def test_translation_interruption_exits_nonzero(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_interrupted_translation.py
+++ b/tests/test_interrupted_translation.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,6 +8,57 @@ from gemini_srt_translator.main import GeminiSRTTranslator
 
 
 class InterruptedTranslationTests(unittest.TestCase):
+    def test_resume_keeps_existing_output_on_disk_until_batch_finishes(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            root = Path(tmp)
+            input_file = root / "sample.en.srt"
+            output_file = root / "sample.zh.srt"
+            progress_file = root / "sample.en.progress"
+            input_file.write_text(
+                "1\n00:00:01,000 --> 00:00:02,000\nHello\n\n"
+                "2\n00:00:03,000 --> 00:00:04,000\nWorld\n",
+                encoding="utf-8",
+            )
+            existing_output = (
+                "1\n00:00:01,000 --> 00:00:02,000\n你好\n\n"
+                "2\n00:00:03,000 --> 00:00:04,000\nWorld\n"
+            )
+            output_file.write_text(existing_output, encoding="utf-8")
+            progress_file.write_text(json.dumps({"line": 2, "input_file": str(input_file)}), encoding="utf-8")
+
+            translator = GeminiSRTTranslator(
+                gemini_api_key="test-key",
+                target_language="Simplified Chinese",
+                input_file=str(input_file),
+                output_file=str(output_file),
+                model_name="gemini-flash-latest",
+                batch_size=1,
+                use_colors=False,
+                resume=True,
+            )
+
+            def stop_after_checking_output(*args):
+                if output_file.read_text(encoding="utf-8") != existing_output:
+                    raise SystemExit("output was truncated before batch finished")
+                raise SystemExit("output remained intact")
+
+            with (
+                patch.object(translator, "getmodels", return_value=["gemini-flash-latest"]),
+                patch.object(translator, "_get_token_limit", return_value=None),
+                patch.object(translator, "_validate_token_size", return_value=True),
+                patch.object(translator, "_process_batch", side_effect=stop_after_checking_output),
+                patch("gemini_srt_translator.main.progress_bar", return_value=None),
+                patch("gemini_srt_translator.main.info_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.warning_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.error_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.success_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.highlight", return_value=None),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    translator.translate()
+
+            self.assertEqual(raised.exception.code, "output remained intact")
+
     def test_translation_interruption_exits_nonzero(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- keep the existing translated output on disk while resumed translation batches are running
- write translated subtitle output through a sibling temp file followed by `os.replace`
- preserve normal POSIX file permissions when replacing output files atomically
- close the existing translated-output read handle with a context manager

## Root cause
When resuming, `translate()` loaded the existing output into memory and then immediately opened the same output path with mode `w`. That truncated the only on-disk partial output before the next batch finished. If the process was killed hard during that window, the saved progress file could point past translated content that no longer existed on disk.

The atomic-write follow-up keeps the crash-safety behavior without changing generated subtitle permissions: existing files keep their mode, and new files use the same umask-derived mode as a normal `open(..., "w")` write.

## Validation
- `python -W error::ResourceWarning -m unittest tests.test_interrupted_translation -v`
- `python -m unittest tests.test_interrupted_translation tests.test_ffmpeg_utils -v`
- `python -m py_compile gemini_srt_translator/*.py` via PowerShell-expanded file list
- Linux container: `python -m unittest tests.test_interrupted_translation -v` against the pushed branch, including POSIX permission tests

Note: `python -m unittest discover -s tests -v` timed out locally because existing test modules such as `tests/test_translate.py` execute real translation flows at import time.
