### PR TITLE
Add resume context size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ gst translate -i subtitle.srt -l "Brazilian Portuguese" --interactive
 # Resume translation from a specific line
 gst translate -i subtitle.srt -l French --start-line 20
 
+# Limit saved-progress resume context to 50 previous lines (0 disables it)
+gst translate -i subtitle.srt -l French --resume --resume-context-size 50
+
 # Suppress output
 gst translate -i subtitle.srt -l French --quiet
 ```
@@ -363,6 +366,7 @@ gst.extract("audio")
 - `audio_chunk_size`: Audio chunk size in seconds for processing (default: 600).
 - `output_file`: Name of the translated file.
 - `start_line`: Starting line for translation.
+- `resume_context_size`: Number of previous lines to include as context when resuming (default: 50, 0 disables resume context).
 - `description`: Description of the translation job.
 - `batch_size`: Batch size (default: 1000).
 - `free_quota`: Signal GST that you are using a free quota (default: True).
@@ -424,6 +428,7 @@ gst.progress_log = True
 gst.thoughts_log = True
 gst.quiet = False
 gst.resume = True
+gst.resume_context_size = 50
 gst.token_stats = True
 gst.token_report = "token_report.json"
 gst.preserve_context = True

--- a/gemini_srt_translator/__init__.py
+++ b/gemini_srt_translator/__init__.py
@@ -51,6 +51,7 @@ audio_chunk_size: int = None
 extract_audio: bool = None
 isolate_voice: bool = None
 start_line: int = None
+resume_context_size: int = None
 description: str = None
 model_name: str = None
 batch_size: int = None
@@ -208,6 +209,9 @@ def translate():
     # (Optional) Line number to start translation from
     gst.start_line = 120
 
+    # (Optional) Number of previous lines to include when resuming (default: 50, 0 disables resume context)
+    gst.resume_context_size = 50
+
     # (Optional) Additional description of the translation task
     gst.description = "This subtitle is from a TV Series called 'Friends'."
 
@@ -302,6 +306,7 @@ def translate():
         "extract_audio": extract_audio,
         "isolate_voice": isolate_voice,
         "start_line": start_line,
+        "resume_context_size": resume_context_size,
         "description": description,
         "model_name": model_name,
         "batch_size": batch_size,

--- a/gemini_srt_translator/cli.py
+++ b/gemini_srt_translator/cli.py
@@ -143,6 +143,8 @@ def cmd_translate(args) -> None:
         gst.audio_chunk_size = args.audio_chunk_size
     if args.start_line:
         gst.start_line = args.start_line
+    if args.resume_context_size is not None:
+        gst.resume_context_size = args.resume_context_size
     if args.description:
         gst.description = args.description
     if args.batch_size:
@@ -406,6 +408,12 @@ Examples:
     translate_parser.add_argument("-o", "--output-file", help="Output file path")
     translate_parser.add_argument("-a", "--audio-file", help="Audio file for context")
     translate_parser.add_argument("-s", "--start-line", type=int, help="Starting line number")
+    translate_parser.add_argument(
+        "--resume-context-size",
+        type=int,
+        default=None,
+        help="Number of previous lines to include as context when resuming (default: 50, 0 disables)",
+    )
     translate_parser.add_argument("-d", "--description", help="Description for translation context")
     translate_parser.add_argument("-m", "--model", help="Gemini model to use")
     translate_parser.add_argument("-b", "--batch-size", type=int, help="Batch size for translation")

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -88,6 +88,7 @@ class GeminiSRTTranslator:
         extract_audio: bool = False,
         isolate_voice: bool = True,
         start_line: int = None,
+        resume_context_size: int = 50,
         description: str = None,
         model_name: str = "gemini-3.5-flash",
         batch_size: int = 1000,
@@ -149,6 +150,7 @@ class GeminiSRTTranslator:
         self.extract_audio = extract_audio
         self.isolate_voice = isolate_voice
         self.start_line = start_line
+        self.resume_context_size = max(0, int(resume_context_size or 0))
         self.description = description
         self.model_name = model_name
         self.batch_size = batch_size
@@ -673,8 +675,8 @@ class GeminiSRTTranslator:
             total = len(original_subtitle)
             batch = []
             previous_message = []
-            if self.start_line > 1:
-                start_idx = max(0, self.start_line - 2 - self.batch_size)
+            if self.start_line > 1 and self.resume_context_size > 0:
+                start_idx = max(0, self.start_line - 1 - self.resume_context_size)
                 parts_user = []
                 subtitle_array: list[SubtitleObject] = []
                 offset = 0

--- a/tests/test_interrupted_translation.py
+++ b/tests/test_interrupted_translation.py
@@ -61,6 +61,66 @@ class InterruptedTranslationTests(unittest.TestCase):
 
             self.assertEqual(raised.exception.code, "output remained intact")
 
+    def test_resume_context_size_limits_initial_resume_context(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            root = Path(tmp)
+            input_file = root / "sample.en.srt"
+            output_file = root / "sample.zh.srt"
+            progress_file = root / "sample.en.progress"
+            input_file.write_text(
+                "1\n00:00:01,000 --> 00:00:02,000\nLine one\n\n"
+                "2\n00:00:03,000 --> 00:00:04,000\nLine two\n\n"
+                "3\n00:00:05,000 --> 00:00:06,000\nLine three\n\n"
+                "4\n00:00:07,000 --> 00:00:08,000\nLine four\n\n"
+                "5\n00:00:09,000 --> 00:00:10,000\nLine five\n",
+                encoding="utf-8",
+            )
+            output_file.write_text(
+                "1\n00:00:01,000 --> 00:00:02,000\n第一行\n\n"
+                "2\n00:00:03,000 --> 00:00:04,000\n第二行\n\n"
+                "3\n00:00:05,000 --> 00:00:06,000\n第三行\n\n"
+                "4\n00:00:07,000 --> 00:00:08,000\n第四行\n\n"
+                "5\n00:00:09,000 --> 00:00:10,000\nLine five\n",
+                encoding="utf-8",
+            )
+            progress_file.write_text(json.dumps({"line": 5, "input_file": str(input_file)}), encoding="utf-8")
+
+            translator = GeminiSRTTranslator(
+                gemini_api_key="test-key",
+                target_language="Simplified Chinese",
+                input_file=str(input_file),
+                output_file=str(output_file),
+                model_name="gemini-flash-latest",
+                batch_size=100,
+                resume=True,
+                resume_context_size=2,
+                use_colors=False,
+            )
+
+            def capture_context(batch, previous_message, translated_subtitle):
+                source_context = json.loads(previous_message[0].parts[0].text)
+                translated_context = json.loads(previous_message[1].parts[0].text)
+                self.assertEqual([line["index"] for line in source_context], ["2", "3"])
+                self.assertEqual([line["index"] for line in translated_context], ["2", "3"])
+                raise SystemExit("context captured")
+
+            with (
+                patch.object(translator, "getmodels", return_value=["gemini-flash-latest"]),
+                patch.object(translator, "_get_token_limit", return_value=None),
+                patch.object(translator, "_validate_token_size", return_value=True),
+                patch.object(translator, "_process_batch", side_effect=capture_context),
+                patch("gemini_srt_translator.main.progress_bar", return_value=None),
+                patch("gemini_srt_translator.main.info_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.warning_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.error_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.success_with_progress", return_value=None),
+                patch("gemini_srt_translator.main.highlight", return_value=None),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    translator.translate()
+
+            self.assertEqual(raised.exception.code, "context captured")
+
     @unittest.skipIf(os.name == "nt", "POSIX permission bits are not meaningful on Windows")
     def test_atomic_write_uses_normal_file_permissions_for_new_output(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add `--resume-context-size` / `resume_context_size` to cap the saved-progress context used when resuming translations
- default resume context to 50 previous lines, with `0` disabling resume context
- document the CLI and Python API option

## Why
When resuming from a saved progress file, the translator previously used `batch_size` as the number of previous lines to send as context. Large batch sizes can turn a small tail resume into a very large request because both source and translated history are sent back to the model.

## Validation
- `python -m unittest tests.test_interrupted_translation.InterruptedTranslationTests.test_resume_context_size_limits_initial_resume_context -v`
- `python -W error::ResourceWarning -m unittest tests.test_interrupted_translation -v`
- `python -m unittest tests.test_interrupted_translation tests.test_ffmpeg_utils -v`
- PowerShell-expanded `python -m py_compile gemini_srt_translator/*.py`
- `git diff --check` (CRLF warnings only on Windows)
