### PR TITLE
Report abort reason in quiet mode

### DIFF
--- a/gemini_srt_translator/logger.py
+++ b/gemini_srt_translator/logger.py
@@ -382,10 +382,17 @@ def warning_with_progress(
 
 
 def error_with_progress(
-    message: Any, chunk_size: int = 0, isSending: bool = False, isTranscribing: bool = False
+    message: Any,
+    chunk_size: int = 0,
+    isSending: bool = False,
+    isTranscribing: bool = False,
+    ignore_quiet: bool = False,
 ) -> None:
     """Update the progress bar with an error message"""
+    if _quiet_mode and not ignore_quiet:
+        return
     if _quiet_mode:
+        error(message, ignore_quiet=True)
         return
     progress_bar(
         **_last_progress,

--- a/gemini_srt_translator/main.py
+++ b/gemini_srt_translator/main.py
@@ -875,15 +875,15 @@ class GeminiSRTTranslator:
                     warning_with_progress(
                         f"Consecutive error count: {self.consecutive_error_count}/{self.max_consecutive_errors}"
                     )
+                    e_str = str(e).lower()
 
                     if self.consecutive_error_count >= self.max_consecutive_errors:
                         error_with_progress(
-                            f"Stopping script due to reaching {self.max_consecutive_errors} consecutive errors to prevent API quota waste."
+                            f"Stopping script due to reaching {self.max_consecutive_errors} consecutive errors to prevent API quota waste. Last error: {e}",
+                            ignore_quiet=True,
                         )
                         signal.raise_signal(signal.SIGINT)
                         time.sleep(2)
-
-                    e_str = str(e).lower()
 
                     if "quota" in e_str:
                         current_time = time.time()
@@ -910,7 +910,8 @@ class GeminiSRTTranslator:
                             continue
                         else:
                             error_with_progress(
-                                f"Model is still overloaded after {max_overload_retries} attempts. Aborting."
+                                f"Model is still overloaded after {max_overload_retries} attempts. Aborting. Last error: {e}",
+                                ignore_quiet=True,
                             )
                             signal.raise_signal(signal.SIGINT)
 

--- a/tests/test_interrupted_translation.py
+++ b/tests/test_interrupted_translation.py
@@ -1,11 +1,14 @@
 import json
+import io
 import os
 import stat
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
+from gemini_srt_translator.logger import set_quiet_mode
 from gemini_srt_translator.main import GeminiSRTTranslator
 
 
@@ -121,6 +124,43 @@ class InterruptedTranslationTests(unittest.TestCase):
                     translator.translate()
 
             self.assertNotEqual(raised.exception.code, 0)
+
+    def test_quiet_overload_abort_reports_last_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_file = root / "sample.en.srt"
+            output_file = root / "sample.zh.srt"
+            input_file.write_text("1\n00:00:01,000 --> 00:00:02,000\nHello\n", encoding="utf-8")
+
+            translator = GeminiSRTTranslator(
+                gemini_api_key="test-key",
+                target_language="Simplified Chinese",
+                input_file=str(input_file),
+                output_file=str(output_file),
+                model_name="gemini-flash-latest",
+                batch_size=1,
+                use_colors=False,
+                resume=False,
+            )
+            captured = io.StringIO()
+
+            set_quiet_mode(True)
+            try:
+                with (
+                    patch.object(translator, "getmodels", return_value=["gemini-flash-latest"]),
+                    patch.object(translator, "_get_token_limit", return_value=None),
+                    patch.object(translator, "_validate_token_size", return_value=True),
+                    patch.object(translator, "_process_batch", side_effect=RuntimeError("503 model overloaded")),
+                    patch("gemini_srt_translator.main.time.sleep", return_value=None),
+                    redirect_stdout(captured),
+                ):
+                    with self.assertRaises(SystemExit) as raised:
+                        translator.translate()
+            finally:
+                set_quiet_mode(False)
+
+            self.assertEqual(raised.exception.code, 130)
+            self.assertIn("503 model overloaded", captured.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include the last exception message when translation aborts after repeated errors
- allow `error_with_progress(..., ignore_quiet=True)` to emit a simple error line even in quiet mode
- add regression coverage for quiet-mode overload abort diagnostics

## Why
Callers that run `gst translate --quiet` currently see exit 130 without any captured output when the translator aborts after repeated overload/API errors. That makes wrappers unable to distinguish model overloads from user interrupts or malformed-output failures.

## Validation
- `python -m unittest tests.test_interrupted_translation.InterruptedTranslationTests.test_quiet_overload_abort_reports_last_error -v`
- `python -W error::ResourceWarning -m unittest tests.test_interrupted_translation -v`
- `python -m unittest tests.test_interrupted_translation tests.test_ffmpeg_utils -v`
- PowerShell-expanded `python -m py_compile gemini_srt_translator/*.py`
- `git diff --check` (CRLF warnings only on Windows)
